### PR TITLE
Исключение codeception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 /web/assets/
 /web/uploads/
 /.phpunit.result.cache
+/untracked
+
+#for tests
+/models/tests
+/tests-c/
+/config/test.sample.php
+codeception.yml

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,14 @@
 		"yiisoft/yii2-debug": "~2.0.0",
 		"yiisoft/yii2-gii": "~2.0.0",
 		"yiisoft/yii2-faker": "~2.0.0",
-		"phpunit/phpunit": "^9.5"
+		"phpunit/phpunit": "^9.5",
+		"codeception/codeception": "^4.1",
+		"codeception/module-asserts": "^1.3",
+		"codeception/module-phpbrowser": "^1.0.0",
+		"codeception/module-yii2": "^1.1",
+		"codeception/module-db": "^1.1",
+		"codeception/module-filesystem": "^1.0",
+		"vlucas/phpdotenv": "^4"
 	},
 	"config": {
 		"process-timeout": 1800,
@@ -62,7 +69,8 @@
 			"yii\\composer\\Installer::postCreateProject",
 			"yii\\composer\\Installer::postInstall"
 		],
-		"test": "phpunit"
+		"test": "phpunit",
+		"codeception": "vendor/bin/codecept run"
 	},
 	"extra": {
 		"yii\\composer\\Installer::postCreateProject": {


### PR DESCRIPTION
Временно добавляю свои локальные папки тестов в игнор, чтобы никому не мешать.
Нужно сделать exclude по файлу vendor/codeception/codeception/autoload.php, чтобы инспекции не ругались.